### PR TITLE
构建强制要求使用 JDK 21

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -11,6 +11,9 @@ pluginManagement {
 
 rootProject.name = 'muyun'
 
+assert JavaVersion.current() >= JavaVersion.VERSION_21:
+    "You must use at least Java 21 to build the project, you're currently using ${System.getProperty("java.version")}"
+
 include 'my-core'
 //include 'my-core-uni'
 include 'my-platform'


### PR DESCRIPTION
如未使用 Java 21 启动 Gradle，则抛出异常