### PR TITLE
Gradle 脚本优化

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+    id 'groovy-gradle-plugin'
+    id 'java-library'
+}
+
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation gradleApi()
+    implementation 'org.kordamp.gradle:jandex-gradle-plugin:2.0.0'
+}

--- a/buildSrc/src/main/groovy/configure-jandex.gradle
+++ b/buildSrc/src/main/groovy/configure-jandex.gradle
@@ -1,0 +1,7 @@
+plugins {
+    id 'org.kordamp.gradle.jandex'
+}
+
+tasks.named('checkstyleMain').configure {
+    dependsOn 'jandex'
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,0 @@
-#Gradle properties
-quarkusPluginId=io.quarkus
-quarkusPluginVersion=3.12.3
-quarkusPlatformGroupId=io.quarkus.platform
-quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=3.12.3

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,14 @@
 [versions]
 testcontainers = "1.20.0"
 
+jandex = "2.0.0"
+
+quarkus = "3.12.3"
+
 [libraries]
 testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }
+
+quarkus-platform-bom = { module = "io.quarkus.platform:quarkus-bom", version.ref = "quarkus" }
+
+[plugins]
+jandex = { id = "org.kordamp.gradle.jandex", version.ref = "jandex" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,6 @@
 [versions]
 testcontainers = "1.20.0"
 
-jandex = "2.0.0"
-
 quarkus = "3.12.3"
 
 [libraries]
@@ -11,4 +9,3 @@ testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.
 quarkus-platform-bom = { module = "io.quarkus.platform:quarkus-bom", version.ref = "quarkus" }
 
 [plugins]
-jandex = { id = "org.kordamp.gradle.jandex", version.ref = "jandex" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,3 +9,4 @@ testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.
 quarkus-platform-bom = { module = "io.quarkus.platform:quarkus-bom", version.ref = "quarkus" }
 
 [plugins]
+quarkus = { id = "io.quarkus", version.ref = "quarkus" }

--- a/my-boot/build.gradle
+++ b/my-boot/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation enforcedPlatform(libs.quarkus.platform.bom)
     implementation project(":my-core")
     implementation project(":my-platform")
 //    implementation project(":my-msg")

--- a/my-boot/build.gradle
+++ b/my-boot/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'io.quarkus'
     id 'checkstyle'
+    alias libs.plugins.quarkus
 }
 
 

--- a/my-core/build.gradle
+++ b/my-core/build.gradle
@@ -1,13 +1,13 @@
 plugins {
     id 'java'
     id 'java-library'
-    id 'org.kordamp.gradle.jandex' version '2.0.0'
+    alias libs.plugins.jandex
     id 'checkstyle'
 }
 
 
 dependencies {
-    api enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    api enforcedPlatform(libs.quarkus.platform.bom)
 
     api project(':my-database')
 

--- a/my-core/build.gradle
+++ b/my-core/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'java'
     id 'java-library'
-    alias libs.plugins.jandex
     id 'checkstyle'
+    id 'configure-jandex'
 }
 
 
@@ -15,11 +15,6 @@ dependencies {
     api 'io.quarkus:quarkus-arc'
     api 'io.quarkus:quarkus-rest-jackson'
 
-
     testImplementation 'io.quarkus:quarkus-junit5'
     testImplementation 'io.rest-assured:rest-assured'
-}
-
-tasks.named('checkstyleMain').configure {
-    dependsOn 'jandex'
 }

--- a/my-database-standard/build.gradle
+++ b/my-database-standard/build.gradle
@@ -1,13 +1,13 @@
 plugins {
     id 'java'
     id 'java-library'
-    id 'org.kordamp.gradle.jandex' version '2.0.0'
+    alias libs.plugins.jandex
     id 'checkstyle'
 }
 
 
 dependencies {
-    api enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    api enforcedPlatform(libs.quarkus.platform.bom)
     implementation project(':my-database')
 
     api "io.quarkus:quarkus-jdbc-postgresql"

--- a/my-database-standard/build.gradle
+++ b/my-database-standard/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'java'
     id 'java-library'
-    alias libs.plugins.jandex
     id 'checkstyle'
+    id 'configure-jandex'
 }
 
 
@@ -11,8 +11,4 @@ dependencies {
     implementation project(':my-database')
 
     api "io.quarkus:quarkus-jdbc-postgresql"
-}
-
-tasks.named('checkstyleMain').configure {
-    dependsOn 'jandex'
 }

--- a/my-database-uni/build.gradle
+++ b/my-database-uni/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.kordamp.gradle.jandex' version '2.0.0'
+    alias libs.plugins.jandex
     id 'checkstyle'
 }
 

--- a/my-database-uni/build.gradle
+++ b/my-database-uni/build.gradle
@@ -1,15 +1,11 @@
 plugins {
     id 'java'
-    alias libs.plugins.jandex
     id 'checkstyle'
+    id 'configure-jandex'
 }
 
 
 dependencies {
     implementation project(':my-database')
 //    implementation project(':my-core-uni')
-}
-
-tasks.named('checkstyleMain').configure {
-    dependsOn 'jandex'
 }

--- a/my-database/build.gradle
+++ b/my-database/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 
 dependencies {
-    api enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    api enforcedPlatform(libs.quarkus.platform.bom)
 //    implementation project(':my-core')
 //    implementation project(':my-core-uni')
 

--- a/my-platform/build.gradle
+++ b/my-platform/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.kordamp.gradle.jandex' version '2.0.0'
+    alias libs.plugins.jandex
     id 'checkstyle'
 }
 

--- a/my-platform/build.gradle
+++ b/my-platform/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    alias libs.plugins.jandex
     id 'checkstyle'
+    id 'configure-jandex'
 }
 
 
@@ -9,8 +9,4 @@ dependencies {
     implementation project(':my-core')
     implementation project(':my-database-standard')
 //    implementation project(':my-core-uni')
-}
-
-tasks.named('checkstyleMain').configure {
-    dependsOn 'jandex'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ pluginManagement {
         mavenLocal()
     }
     plugins {
-        id "${quarkusPluginId}" version "${quarkusPluginVersion}"
+        id "io.quarkus" version "3.12.3"
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,14 +1,3 @@
-pluginManagement {
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-        mavenLocal()
-    }
-    plugins {
-        id "io.quarkus" version "3.12.3"
-    }
-}
-
 plugins {
     id "com.gradle.develocity" version "3.17.5"
 }


### PR DESCRIPTION
1. 使用 libs.versions.toml 统一管理 Gradle 依赖信息
2. 将 jandex 封装为插件
    将 jandex 插件与 checkstyle 兼容配置整合到一个插件中，便于使用
